### PR TITLE
except ValueError instead

### DIFF
--- a/scribdl/scribdl.py
+++ b/scribdl/scribdl.py
@@ -202,7 +202,7 @@ class ScribdBook:
 
                 chapter += 1
 
-            except json.decoder.JSONDecodeError:
+            except ValueError:
                 print('No more content being exposed by Scribd!')
                 pdf_out = '{}.pdf'.format(book_id)
                 print('Generating PDF file: {}'.format(pdf_out))


### PR DESCRIPTION
json.decoder.JSONDecodeError exception does not seem to exist in Python 2.7 but from Python 3 and actually it raises ValueError, however in newer versions it raises JSONDecodeError exception which inherits ValueError class so fixing this would make the code more generic and work with both major versions.